### PR TITLE
Fix incorrect examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ endpointParser.decompose('backbone=backbone-amd#~1.0.0');
 // { name: 'backbone', source: 'backbone-amd', target: '~1.0.0' }
 
 endpointParser.decompose('http://twitter.github.io/bootstrap/assets/bootstrap.zip');
-// { name: '', source: 'http://twitter.github.io/bootstrap/assets/bootstrap', target: '*' }
+// { name: '', source: 'http://twitter.github.io/bootstrap/assets/bootstrap.zip', target: '*' }
 
 endpointParser.decompose('bootstrap=http://twitter.github.io/bootstrap/assets/bootstrap.zip');
-// { name: 'bootstrap', source: 'http://twitter.github.io/bootstrap/assets/bootstrap', target: '*' }
+// { name: 'bootstrap', source: 'http://twitter.github.io/bootstrap/assets/bootstrap.zip', target: '*' }
 ```
 
 ### .compose(decEndpoint)
@@ -44,10 +44,10 @@ endpointParser.compose({ name: '', source: 'jquery', target: '~2.0.0' });
 endpointParser.compose({ name: 'backbone', source: 'backbone-amd', target: '~1.0.0' });
 // backbone=backbone-amd#~1.0.0
 
-endpointParser.compose({ name: '', source: 'http://twitter.github.io/bootstrap/assets/bootstrap', target: '*' });
+endpointParser.compose({ name: '', source: 'http://twitter.github.io/bootstrap/assets/bootstrap.zip', target: '*' });
 // http://twitter.github.io/bootstrap/assets/bootstrap.zip
 
-endpointParser.compose({ name: 'bootstrap', source: 'http://twitter.github.io/bootstrap/assets/bootstrap', target: '*' });
+endpointParser.compose({ name: 'bootstrap', source: 'http://twitter.github.io/bootstrap/assets/bootstrap.zip', target: '*' });
 // bootstrap=http://twitter.github.io/bootstrap/assets/bootstrap.zip
 ```
 


### PR DESCRIPTION
There are some examples in the README for compose/decompose, which do not align with how the code actually works.


### For example:

![screen_shot_2015-07-11_at_8_07_27_pm](https://cloud.githubusercontent.com/assets/558005/8636176/a7697396-2808-11e5-8123-e735bedd7e4e.png)

vs.

**tests:** https://github.com/bower/endpoint-parser/blob/master/test/test.js#L52-L53

Note that the README indicates that the `.zip` extension will be added as part of `compose()`, whereas the tests indicate that the `.zip` will simply be preserved if present in the decomposed package information. 

Testing this package manually indicates that of course the tests are correct

![screen shot 2015-07-11 at 8 10 43 pm](https://cloud.githubusercontent.com/assets/558005/8636184/f0583dbc-2808-11e5-850a-68e07abfb62d.png)
